### PR TITLE
V1.1

### DIFF
--- a/kq.py
+++ b/kq.py
@@ -49,6 +49,9 @@ def binaryzation(image, threshold):
 
 # 打卡
 def do_kq(check_pass = False):
+    option = webdriver.ChromeOptions ()
+    # 禁止浏览器弹出警告
+    option.add_argument ('disable-infobars')
     driver = webdriver.Chrome()
     driver.get('http://kq.neusoft.com/')
 
@@ -79,7 +82,7 @@ def do_kq(check_pass = False):
 
     image = binaryzation(image, threshold=127)
 
-    code = pytesseract.image_to_string(image)
+    code = pytesseract.image_to_string(image, lang = 'eng', config = '--pms 6')
 
     print('the code is', code)
 


### PR DESCRIPTION
1. 添加代码，消除Chome浏览器打开时的警告。
2. 添加代码，消除Windows 下 tesseract识别二维码无效的情况。